### PR TITLE
Adds missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pandas==0.20.3
 dateparser==0.7.0
 beautifulsoup4==4.6.0
+spacy==2.0.12
+pyspotlight==0.7.2
+rdflib==4.2.2


### PR DESCRIPTION
There were some missing dependencies after running pip install -r requirements.txt. This should fix that.